### PR TITLE
Set OutputPath of demo-assembly

### DIFF
--- a/src/demo-assembly/demo-assembly.csproj
+++ b/src/demo-assembly/demo-assembly.csproj
@@ -20,7 +20,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>..\..\bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -31,7 +31,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>..\..\bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>


### PR DESCRIPTION
While building I noticed that the dll of the demo-assembly ended up in another location than all the other dlls.

> ...
> Microsoft (R) Build Engine version 15.1.1012.6693
> Copyright (C) Microsoft Corporation. All rights reserved.
> 
>   nunit.testmodel   -> C:\src\NUnit\nunit-gui\bin\Debug\nunit.testmodel.dll
>   nunit.uikit       -> C:\src\NUnit\nunit-gui\bin\Debug\nunit.uikit.dll
>   nunit-gui         -> C:\src\NUnit\nunit-gui\bin\Debug\nunit-gui.exe
>   mock-assembly     -> C:\src\NUnit\nunit-gui\bin\Debug\mock-assembly.dll
>   nunit-gui.tests   -> C:\src\NUnit\nunit-gui\bin\Debug\nunit-gui.tests.dll
>   demo-assembly     -> C:\src\NUnit\nunit-gui\src\demo-assembly\bin\Debug\demo-assembly.dll

Hence, the OutputPath of the demo-assembly is now set to the same folders as the other projects.