### PR TITLE
Separate C# GUI initialization logic from the rest of the entry point

### DIFF
--- a/src/nunit-gui/Program.cs
+++ b/src/nunit-gui/Program.cs
@@ -43,7 +43,11 @@ namespace NUnit.Gui
         {
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
+            Run(args);
+        }
 
+        public static void Run(string[] args)
+        {
             CommandLineOptions options = new CommandLineOptions();
             try
             {


### PR DESCRIPTION
This simple PR is intended to allow another program to act as a wrapper for the GUI runner. Currently, one can invoke the runner via inflection, but if one uses C# forms BEFORE invoking the runner, the GUI initialization logic in `Main` throws an exception. In my case, for instance, I was initializing a C# form for easy configuration of the args passed to the NUnit GUI runner, and the following exception would get thrown upon using reflection to call `Main`:

```
Unhandled Exception: System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.InvalidOperationException: SetCompatibleTextRenderingDefault must be called before the first IWin32Window object is created in the application.
   at System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(Boolean defaultValue)
   at NUnit.Gui.Program.Main(String[] args)
   --- End of inner exception stack trace ---
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor)
   at System.Reflection.RuntimeMethodInfo.UnsafeInvokeInternal(Object obj, Object[] parameters, Object[] arguments)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
// ...
```

With this change, clients can now invoke the 

```
var guiRunnerAssembly = Assembly.LoadFile("...\\nunit-gui.exe");
guiRunnerAssembly.EntryPoint.DeclaringType.GetMethod("Run").Invoke(null, new object[] { args });
```