### PR TITLE
Only set TestXml when relevant

### DIFF
--- a/src/nunit-gui/Presenters/XmlPresenter.cs
+++ b/src/nunit-gui/Presenters/XmlPresenter.cs
@@ -74,6 +74,8 @@ namespace NUnit.Gui.Presenters
             {
                 _view.XmlTextBox.Control.Copy();
             };
+
+            _view.ViewGotFocus += () => DisplayXml();
         }
 
         private void OnSelectedItemChanged(ITestItem testItem)
@@ -92,7 +94,8 @@ namespace NUnit.Gui.Presenters
             {
                 _view.SuspendLayout();
                 _view.Header = testNode.Name;
-                _view.TestXml = GetFullXml(testNode);
+                if (_view.Visible)
+                    _view.TestXml = GetFullXml(testNode);
                 _view.ResumeLayout();
             }
             else if (_selectedItem != null)

--- a/src/nunit-gui/Views/IXmlView.cs
+++ b/src/nunit-gui/Views/IXmlView.cs
@@ -41,5 +41,6 @@ namespace NUnit.Gui.Views
         event CommandHandler SelectionChanged;
         event CommandHandler CopyCommand;
         event CommandHandler WordWrapChanged;
+        event CommandHandler ViewGotFocus;
     }
 }

--- a/src/nunit-gui/Views/MainForm.Designer.cs
+++ b/src/nunit-gui/Views/MainForm.Designer.cs
@@ -722,6 +722,7 @@
             this.tabControl1.SelectedIndex = 0;
             this.tabControl1.Size = new System.Drawing.Size(349, 362);
             this.tabControl1.TabIndex = 1;
+            this.tabControl1.SelectedIndexChanged += new System.EventHandler(this.TabControlSelectedIndexChanged);
             // 
             // tabPage2
             // 

--- a/src/nunit-gui/Views/MainForm.cs
+++ b/src/nunit-gui/Views/MainForm.cs
@@ -189,5 +189,11 @@ namespace NUnit.Gui.Views
             if (files != null)
                 DragDropFiles?.Invoke(files);
         }
+
+        private void TabControlSelectedIndexChanged(object sender, System.EventArgs e)
+        {
+            if (tabControl1.SelectedIndex == 1)
+                XmlView.InvokeFocus();
+        }
     }
 }

--- a/src/nunit-gui/Views/MainForm.cs
+++ b/src/nunit-gui/Views/MainForm.cs
@@ -192,7 +192,7 @@ namespace NUnit.Gui.Views
 
         private void TabControlSelectedIndexChanged(object sender, System.EventArgs e)
         {
-            if (tabControl1.SelectedIndex == 1)
+            if (tabControl1.SelectedTab.Equals(tabPage2))
                 XmlView.InvokeFocus();
         }
     }

--- a/src/nunit-gui/Views/XmlView.cs
+++ b/src/nunit-gui/Views/XmlView.cs
@@ -35,6 +35,7 @@ namespace NUnit.Gui.Views
         public event CommandHandler SelectionChanged;
         public event CommandHandler CopyCommand;
         public event CommandHandler WordWrapChanged;
+        public event CommandHandler ViewGotFocus;
 
         public XmlView()
         {
@@ -67,7 +68,6 @@ namespace NUnit.Gui.Views
                 if (WordWrapChanged != null)
                     WordWrapChanged();
             };
-
         }
 
         public string Header
@@ -92,6 +92,11 @@ namespace NUnit.Gui.Views
                 _testXml = value;
                 InvokeIfRequired(() => xmlTextBox.Rtf = TestXml != null ? XmlHelper.ToRtfString(_testXml, 2) : "");
             }
+        }
+
+        public void InvokeFocus()
+        {
+            ViewGotFocus?.Invoke();
         }
 
         #region Helper Methods


### PR DESCRIPTION
TestXml is now set when:
* We change from the tab "Properties" to the tab "XML"
* Or when the tab "XML" is visible and the selected item in the tree changes

This improves the performance of most operations in the gui
(i.e. all operations as long as the "XML" tab is not selected). The only
downside is that going back and forth between the tabs will retrigger
a call to `DisplayXml`.

To improve the experience even more `GetFullXml` and `XmlHelper.ToRtfString`
could be done asynchronous and results could be cached.

Relates to #241