### PR TITLE
Avoid "The path is not of a legal form" GUI crash

### DIFF
--- a/src/nunit-gui/Presenters/TestPropertiesPresenter.cs
+++ b/src/nunit-gui/Presenters/TestPropertiesPresenter.cs
@@ -206,7 +206,9 @@ namespace NUnit.Gui.Presenters
 
         public static string GetTestType(TestNode testNode)
         {
-            if (testNode.RunState == RunState.NotRunnable && testNode.Type == "Assembly")
+            if (testNode.RunState == RunState.NotRunnable
+                && testNode.Type == "Assembly"
+                && !String.IsNullOrEmpty(testNode.FullName))
             {
                 var fi = new FileInfo(testNode.FullName);
                 string extension = fi.Extension.ToLower();


### PR DESCRIPTION
Note that we currently do not show top-level failures
(a failure-node just inside the outermost test-suite-node)
in the GUI (except in the XML tab), but at least the GUI
does not crash anymore.

Relates to #228 and #184